### PR TITLE
Fe 13: As a user, I want to view which requirements are edited and want edits to be saved properly

### DIFF
--- a/src/components/RequirementsList/RequirementsList.css
+++ b/src/components/RequirementsList/RequirementsList.css
@@ -9,3 +9,13 @@
 .requirement-text {
     font-size: 10px;
 }
+
+.sublist {
+    width: 100%;
+}
+
+.edited-symbol {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+}

--- a/src/components/RequirementsList/RequirementsList.js
+++ b/src/components/RequirementsList/RequirementsList.js
@@ -12,12 +12,13 @@ import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
 import './RequirementsList.css';
 
-const RequirementsList = ({ requirementsList, disabled, showUnmet }) => {
+const RequirementsList = ({ requirementsList, metConditions, disabled, showUnmet }) => {
   const [checked, setChecked] = React.useState([]);
   const [open, setOpen] = React.useState([]);
 
   // inits checkboxes
   useEffect(() => {
+    console.log(metConditions);
     setChecked([]);
     requirementsList.map((header) => {
       header.requirements.map((req) => {
@@ -26,7 +27,7 @@ const RequirementsList = ({ requirementsList, disabled, showUnmet }) => {
         }
       })
     })
-  }, [requirementsList]);
+  }, [metConditions]);
 
   // when the user opens/ closes the drop down
   const handleOpen = (value) => () => {
@@ -43,14 +44,14 @@ const RequirementsList = ({ requirementsList, disabled, showUnmet }) => {
   // when the user checks/ unchecks a box
   const handleCheck = (value) => () => {
     if (disabled) {return;}
-    const currentIndex = checked.indexOf(value);
-    const newChecked = [...checked];
-    if (currentIndex === -1) {
-      newChecked.push(value);
-    } else {
-      newChecked.splice(currentIndex, 1);
-    }
-    setChecked(newChecked);
+    // const currentIndex = checked.indexOf(value);
+    // const newChecked = [...checked];
+    // if (currentIndex === -1) {
+    //   newChecked.push(value);
+    // } else {
+    //   newChecked.splice(currentIndex, 1);
+    // }
+    // setChecked(newChecked);
   };
 
   return (
@@ -102,7 +103,7 @@ const RequirementsList = ({ requirementsList, disabled, showUnmet }) => {
                   >
                     <ListItemIcon key={`ListItemIcon-${req.title}`} >
                       <Checkbox
-                        checked={checked.indexOf(req.title) !== -1}
+                        checked={metConditions ? metConditions.requirements[req.title] : false}
                         tabIndex={-1}
                         key={`Checkbox-${req.title}`}
                         disableRipple
@@ -135,6 +136,7 @@ const RequirementsList = ({ requirementsList, disabled, showUnmet }) => {
 
 RequirementsList.propTypes = {
     requirementsList: PropTypes.array.isRequired,
+    metConditions: PropTypes.object.isRequired,
     disabled: PropTypes.bool.isRequired,
     showUnmet: PropTypes.bool.isRequired,
 };

--- a/src/components/RequirementsList/RequirementsList.js
+++ b/src/components/RequirementsList/RequirementsList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -12,22 +12,8 @@ import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
 import './RequirementsList.css';
 
-const RequirementsList = ({ requirementsList, metConditions, disabled, showUnmet }) => {
-  const [checked, setChecked] = React.useState([]);
-  const [open, setOpen] = React.useState([]);
-
-  // inits checkboxes
-  useEffect(() => {
-    console.log(metConditions);
-    setChecked([]);
-    requirementsList.map((header) => {
-      header.requirements.map((req) => {
-        if (req.met) {
-          setChecked(prevChecked => [...prevChecked, req.title]);
-        }
-      })
-    })
-  }, [metConditions]);
+const RequirementsList = ({ requirementsList, metConditions, setMetConditions, disabled, showUnmet }) => {
+  const [open, setOpen] = useState([]);
 
   // when the user opens/ closes the drop down
   const handleOpen = (value) => () => {
@@ -43,15 +29,16 @@ const RequirementsList = ({ requirementsList, metConditions, disabled, showUnmet
 
   // when the user checks/ unchecks a box
   const handleCheck = (value) => () => {
-    if (disabled) {return;}
-    // const currentIndex = checked.indexOf(value);
-    // const newChecked = [...checked];
-    // if (currentIndex === -1) {
-    //   newChecked.push(value);
-    // } else {
-    //   newChecked.splice(currentIndex, 1);
-    // }
-    // setChecked(newChecked);
+    if (disabled) {return}
+    var newCond = [];
+    for (var key in metConditions) {
+      if (key == value) {
+        newCond[key] = {met: !metConditions[value].met, edited: !metConditions[value].edited};
+      } else {
+        newCond[key] = metConditions[key];
+      }
+    }
+    setMetConditions(newCond);
   };
 
   return (
@@ -90,40 +77,50 @@ const RequirementsList = ({ requirementsList, metConditions, disabled, showUnmet
             unmountOnExit
           >
             <List component='div' key={`List-${value.title}`}>
-              {value.requirements.filter(value => !showUnmet || checked.indexOf(value.title) == -1 ).map((req => {
+              {value.requirements.filter(value => !showUnmet || metConditions[value.title].met ).map((req => {
                 return (
-                <ListItem
-                  key={`ListItem-${req.title}`}
-                  className='list-requirement'
-                >
-                  <ListItemButton  
-                    key={`ListItemButton-${req.title}`} 
-                    role={undefined} 
+                  <ListItemButton
+                    key={`ListItemButton-${req.title}`}
+                    role={undefined}
                     onClick={handleCheck(req.title)}
                   >
-                    <ListItemIcon key={`ListItemIcon-${req.title}`} >
-                      <Checkbox
-                        checked={metConditions ? metConditions.requirements[req.title] : false}
-                        tabIndex={-1}
-                        key={`Checkbox-${req.title}`}
-                        disableRipple
-                        id={`Checkbox-${req.title}`}
-                      />
-                    </ListItemIcon>
-                    <ListItemText 
-                      className='requirement-text' 
-                      key={`ListItemText-${req.title}`} 
-                      disabletypography='true' 
-                      primary={
-                        <Typography 
-                          key={`Typography-${req.title}`}  
-                          variant='body3'
+                    <List key={`List-${req.title}`} className='sublist'>
+                      <ListItem key={`outerListItem-${req.title}`}>
+                        <ListItemIcon key={`ListItemIcon-${req.title}`}>
+                          <Checkbox
+                            checked={metConditions[req.title].met}
+                            tabIndex={-1}
+                            key={`Checkbox-${req.title}`}
+                            disableRipple
+                            id={`Checkbox-${req.title}`}
+                          />
+                        </ListItemIcon>
+                        <ListItemText
+                          className='requirement-text'
+                          key={`ListItemText-${req.title}`}
+                          disabletypography='true'
+                          primary={
+                            <Typography
+                              key={`Typography-${req.title}`}
+                              variant='body3'
+                            >
+                              {req.title}
+                            </Typography>
+                          }
+                        />
+                      </ListItem>
+                      {metConditions[req.title].edited && 
+                        <Typography
+                        key={`Typography-edited-${req.title}`}
+                        className='edited-symbol'
+                        variant='body4'
                         >
-                          {req.title}
-                        </Typography>} 
-                    />
+                          edited
+                        </Typography>
+                      }
+                    </List>
                   </ListItemButton>
-                </ListItem>);
+                );
               }))}
             </List>
           </Collapse>
@@ -136,7 +133,8 @@ const RequirementsList = ({ requirementsList, metConditions, disabled, showUnmet
 
 RequirementsList.propTypes = {
     requirementsList: PropTypes.array.isRequired,
-    metConditions: PropTypes.object.isRequired,
+    metConditions: PropTypes.array.isRequired,
+    setMetConditions: PropTypes.func.isRequired,
     disabled: PropTypes.bool.isRequired,
     showUnmet: PropTypes.bool.isRequired,
 };

--- a/src/components/RequirementsList/_test_/RequirementsList.test.js
+++ b/src/components/RequirementsList/_test_/RequirementsList.test.js
@@ -1,11 +1,19 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import RequirementsList from '../RequirementsList';
-import pdfRequirements from './mocks';
+import RequirementsListMocks from './mocks';
 
 describe('RequirementsList', () => {
     test('Renders headers', () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={false} showUnmet={false} />);
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
         const element1 = screen.getByText('Page Formatting & Font');
         expect(element1).toBeInTheDocument();
         const element2 = screen.getByText('Page Order & Section Formatting');
@@ -13,7 +21,15 @@ describe('RequirementsList', () => {
     });
 
     test('Renders requirements', () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={false} showUnmet={false} />);
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
         const element1 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
         expect(element1).toBeInTheDocument();
         const element2 = screen.getByText('No Blank pages in the documents');
@@ -23,7 +39,15 @@ describe('RequirementsList', () => {
     });
 
     test('When a header is collapsed, the requirements are hidden', async () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={false} showUnmet={false} />);
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
         const textElement1 = 'Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs';
         const textElement2 = '2 double spaces beneath title';
         expect(screen.queryByText(textElement1)).toBeInTheDocument();
@@ -38,37 +62,79 @@ describe('RequirementsList', () => {
     });
 
     test('Checkboxes are correctly initialized on render', () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={true} showUnmet={false} />);
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
         const elements = screen.getAllByTestId('CheckBoxIcon');
         expect(elements.length).toBe(2);
     });
 
     test('Checkboxes can be changed when they are not disabled', async () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={false} showUnmet={false} />);
+        const setMetConditions = jest.fn();
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={setMetConditions}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
         const button1 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
         fireEvent.click(button1);
-        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+        expect(setMetConditions).toHaveBeenCalled();
     });
 
     test('Checkboxes can not be changed when they are disabled', async () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={true} showUnmet={false} />);
+        const setMetConditions = jest.fn();
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={setMetConditions}
+                disabled={true} 
+                showUnmet={false} 
+            />
+        );
         const button1 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
         fireEvent.click(button1);
-        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(2));
+        expect(setMetConditions).not.toHaveBeenCalled();
     });
 
     test('When showUnmet is true, only unmet conditions are shown', () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={true} showUnmet={true} />);
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={true} 
+            />
+        );
         const element1 = screen.queryByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
-        expect(element1).not.toBeInTheDocument();
+        expect(element1).toBeInTheDocument();
         const element2 = screen.queryByText('No Blank pages in the documents');
-        expect(element2).toBeInTheDocument();
+        expect(element2).not.toBeInTheDocument();
         const element3 = screen.queryByText('2 double spaces beneath title');
-        expect(element3).not.toBeInTheDocument();
+        expect(element3).toBeInTheDocument();
     });
 
     test('When showUnmet is false, only all conditions are shown', () => {
-        render(<RequirementsList requirementsList={pdfRequirements['header']} disabled={true} showUnmet={false} />);
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
         const element1 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
         expect(element1).toBeInTheDocument();
         const element2 = screen.getByText('No Blank pages in the documents');
@@ -76,5 +142,34 @@ describe('RequirementsList', () => {
         const element3 = screen.getByText('2 double spaces beneath title');
         expect(element3).toBeInTheDocument();
     });
+
+    test('Should not show edited on requirement if it is not edited', () => {
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsInitial}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
+        const element = screen.queryAllByText('edited');
+        expect(element.length).toBe(0);
+    });
+
+    test('Should show edited on requirement if it is edited', () => {
+        render(
+            <RequirementsList 
+                requirementsList={RequirementsListMocks.pdfRequirementsMet} 
+                metConditions={RequirementsListMocks.metConditionsEdited}
+                setMetConditions={jest.fn()}
+                disabled={false} 
+                showUnmet={false} 
+            />
+        );
+        const element = screen.queryAllByText('edited');
+        expect(element.length).toBe(2);
+    });
+
 
 })

--- a/src/components/RequirementsList/_test_/mocks.js
+++ b/src/components/RequirementsList/_test_/mocks.js
@@ -1,6 +1,5 @@
-const pdfRequirementsMet = {
-    message: 'retrive PDF requirements succesfully',
-    header: [
+const RequirementsListMocks = {
+    pdfRequirementsMet: [
         {
             title: 'Page Formatting & Font',
             requirements: [
@@ -23,7 +22,35 @@ const pdfRequirementsMet = {
                 },
             ],
         },
-    ]
+    ],
+    metConditionsInitial: {
+        'Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs': {
+            met: true,
+            edited: false
+        },
+        'No Blank pages in the documents': {
+            met: false,
+            edited: false
+        },
+        '2 double spaces beneath title': {
+            met: true,
+            edited: false
+        }
+    },
+    metConditionsEdited: {
+        'Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs': {
+            met: false,
+            edited: true
+        },
+        'No Blank pages in the documents': {
+            met: true,
+            edited: true
+        },
+        '2 double spaces beneath title': {
+            met: true,
+            edited: false
+        }
+    }
 };
 
-export default pdfRequirementsMet;
+export default RequirementsListMocks;

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -40,6 +40,11 @@ const theme = createTheme({
       color: '#000000',
       fontFamily: ['Roboto','Helvetica','Arial','sans-serif']
     },
+    body4: {
+      fontSize: 18,
+      color: '#9E1B32',
+      fontFamily: ['Roboto','Helvetica','Arial','sans-serif']
+    },
     button: {
       textTransform: 'none',
       fontSize: '20px',

--- a/src/views/Inspect/Inspect.js
+++ b/src/views/Inspect/Inspect.js
@@ -37,6 +37,16 @@ const Inspect = ({ setPage, uploadedFiles, setUploadedFiles, requirementsList })
     setSelectedMetConditions(metConditions[selectedIndex]);
   }, [selectedIndex]);
 
+  // Check if any edits were made
+  const checkEdits = () => {
+    for (var key in selectedMetConditions) {
+      if (selectedMetConditions[key].met != metConditions[selectedIndex][key].met) {
+        return false;
+      }
+    }
+    return true;  
+  };
+
   const handleEditClick = () => {
     // if done editing, update the met conditions
     if (editing == true) {
@@ -94,7 +104,8 @@ const Inspect = ({ setPage, uploadedFiles, setUploadedFiles, requirementsList })
         title='Save changes?' 
         desc='Continue to save edits to the requirements.' 
         continueAction={() => {
-          setEditAlertOpen(false);handleEditClick();
+          setEditAlertOpen(false);
+          handleEditClick();
         }} 
         backAction={() => {
           setEditAlertOpen(false)
@@ -167,7 +178,11 @@ const Inspect = ({ setPage, uploadedFiles, setUploadedFiles, requirementsList })
         )}
         <ContinueButton action={() => {
           if (editing) {
-            setEditAlertOpen(true);
+            if (checkEdits()) {
+              setEditing(false);
+            } else {
+              setEditAlertOpen(true);
+            }
           } else {
             setAlertOpen(true);
           }

--- a/src/views/Inspect/Inspect.js
+++ b/src/views/Inspect/Inspect.js
@@ -13,6 +13,7 @@ import './Inspect.css';
 
 const Inspect = ({ setPage, uploadedFiles, setUploadedFiles, requirementsList }) => {
   const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [metConditions, setMetConditions] = React.useState([]);
   const [editing, setEditing] = React.useState(false);
   const [showUnmet, setShowUnmet] = React.useState(false);
   const [url, setUrl] = React.useState('');
@@ -20,6 +21,22 @@ const Inspect = ({ setPage, uploadedFiles, setUploadedFiles, requirementsList })
   useEffect(() => {
     setUrl(URL.createObjectURL(uploadedFiles[selectedIndex]));
   }, [selectedIndex]);
+
+  useEffect(() => {
+    var requirementArray = [];
+    var metArray = [];
+    requirementsList.map((file) => {
+      console.log(file);
+      file.header.map((header) => {
+        header.requirements.map((req) => {
+          metArray[req.title] = req.met;
+        })
+      })
+      // const [requirements, setRequirements] = React.useState(metArray);
+      requirementArray.push({requirements: [], setRequirements: []});
+    })
+    setMetConditions(requirementArray);
+  }, []);
 
   const handleEditClick = () => {
     setEditing(!editing);   
@@ -53,7 +70,7 @@ const Inspect = ({ setPage, uploadedFiles, setUploadedFiles, requirementsList })
         <div className='right-list-container'>
           <FormControlLabel control={<Switch onChange={handleUnmetSwitch} />} label='Show only unmet conditons' className='switch' />
           <div className='requirements-list-container'>
-            <RequirementsList requirementsList={requirementsList[selectedIndex].header} disabled={!editing} showUnmet={showUnmet} />
+            <RequirementsList requirementsList={requirementsList[selectedIndex].header} metConditions={metConditions[selectedIndex]} disabled={!editing} showUnmet={showUnmet} />
           </div>
         </div>
       </div>

--- a/src/views/Inspect/_test_/Inspect.test.js
+++ b/src/views/Inspect/_test_/Inspect.test.js
@@ -121,13 +121,43 @@ describe('Inspect', () => {
         await waitFor(() =>  expect(screen.queryByText('Reset All Conditions')).toBeInTheDocument());
     });
 
-    test('Renders alert when continue is pressed when editing a file', async () => {
+    test('Does not render alert when continue is pressed when editing a file if no edits are made', async () => {
         render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
         const button1 = screen.getByText('Edit/ View Selected File');
         fireEvent.click(button1);
         await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
         fireEvent.click(screen.queryByText('Continue'));
+        await waitFor(() =>  expect(screen.queryByText('Save changes?')).not.toBeInTheDocument());
+        const element = screen.queryByText('Uploaded Files');
+        expect(element).toBeInTheDocument();
+    });
+
+    test('Should render alert when continue is pressed when editing a file if edits are made', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+        fireEvent.click(screen.queryByText('Continue'));
         await waitFor(() =>  expect(screen.getByText('Save changes?')).toBeInTheDocument());
+    });
+
+    test('Should not render alert when continue is pressed when editing a file if edits are made but then reversed', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+        fireEvent.click(screen.queryByText('Continue'));
+        await waitFor(() =>  expect(screen.queryByText('Save changes?')).not.toBeInTheDocument());
+        const element = screen.queryByText('Uploaded Files');
+        expect(element).toBeInTheDocument();
     });
 
     test('Should render the file list and correct buttons when continue on the alert is pressed when editing a file', async () => {
@@ -136,9 +166,6 @@ describe('Inspect', () => {
         fireEvent.click(button1);
         await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
         fireEvent.click(screen.queryByText('Continue'));
-        await waitFor(() =>  expect(screen.getByText('Save changes?')).toBeInTheDocument());
-        const alertButton = screen.getAllByText('Continue')[1];
-        fireEvent.click(alertButton);
         await waitFor(() =>  expect(screen.queryByText('Edit/ View Selected File')).toBeInTheDocument());
         await waitFor(() =>  expect(screen.queryByText('Download Summaries')).toBeInTheDocument());
         await waitFor(() =>  expect(screen.queryByText('Reset All Conditions')).not.toBeInTheDocument());
@@ -150,6 +177,9 @@ describe('Inspect', () => {
         const button1 = screen.getByText('Edit/ View Selected File');
         fireEvent.click(button1);
         await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
         fireEvent.click(screen.queryByText('Continue'));
         await waitFor(() =>  expect(screen.getByText('Save changes?')).toBeInTheDocument());
         const alertButton = screen.getByText('Back');

--- a/src/views/Inspect/_test_/Inspect.test.js
+++ b/src/views/Inspect/_test_/Inspect.test.js
@@ -99,9 +99,9 @@ describe('Inspect', () => {
         render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
         const button1 = screen.getByText('Show only unmet conditons');
         fireEvent.click(button1);
-        await waitFor(() =>  expect(screen.queryByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs')).not.toBeInTheDocument());
-        await waitFor(() =>  expect(screen.queryByText('No Blank pages in the documents')).toBeInTheDocument());
-        await waitFor(() =>  expect(screen.queryByText('2 double spaces beneath title')).not.toBeInTheDocument());
+        await waitFor(() =>  expect(screen.queryByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs')).toBeInTheDocument());
+        await waitFor(() =>  expect(screen.queryByText('No Blank pages in the documents')).not.toBeInTheDocument());
+        await waitFor(() =>  expect(screen.queryByText('2 double spaces beneath title')).toBeInTheDocument());
     });
 
     test('Should not show file list when editing a file', async () => {
@@ -159,5 +159,111 @@ describe('Inspect', () => {
         expect(element).not.toBeInTheDocument();
     });
 
+    test('Checkboxes can be changed when editing', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+    });
+
+    test('Checkboxes can not be changed when not editing', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(2));
+    });
+
+    test('Show edited when a requirement is edited', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+    });
+
+    test('Remove edited when a requirement is edited twice', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+    });
+
+    test('Should show edited when a condition is edited, even after the file has been switched', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryByText('Continue')).toBeInTheDocument());
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+        fireEvent.click(screen.queryByText('Continue'));
+        await waitFor(() =>  expect(screen.getByText('Save changes?')).toBeInTheDocument());
+        const alertButton = screen.getAllByText('Continue')[1];
+        fireEvent.click(alertButton);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+        const button3 = screen.getByText('file2.pdf');
+        fireEvent.click(button3);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+        const button4 = screen.getByText('file1.pdf');
+        fireEvent.click(button4);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+    });
+
+    test('Should save changes when a condition is edited, even after the file has been switched', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(2));
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+        fireEvent.click(screen.queryByText('Continue'));
+        await waitFor(() =>  expect(screen.getByText('Save changes?')).toBeInTheDocument());
+        const alertButton = screen.getAllByText('Continue')[1];
+        fireEvent.click(alertButton);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+        const button3 = screen.getByText('file2.pdf');
+        fireEvent.click(button3);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+        const button4 = screen.getByText('file1.pdf');
+        fireEvent.click(button4);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+    });
+
+    test('Should remove edited when reset to original button is pressed', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(1));
+        const button3 = screen.getByText('Reset All Conditions');
+        fireEvent.click(button3);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+    });
+
+    test('Should reset conditions when reset to original button is pressed', async () => {
+        render(<Inspect setPage={jest.fn()} uploadedFiles={[{name: 'file1.pdf'}, {name: 'file2.pdf'}, {name: 'file3.pdf'}]} setUploadedFiles={jest.fn()} requirementsList={pdfRequirementsMet.files} />);
+        const button1 = screen.getByText('Edit/ View Selected File');
+        fireEvent.click(button1);
+        await waitFor(() =>  expect(screen.queryAllByText('edited').length).toBe(0));
+        const button2 = screen.getByText('Font: Use a standard 12-point font consistently throughout the document, including headings and subheadings, and must be black font including URLs');
+        fireEvent.click(button2);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(1));
+        const button3 = screen.getByText('Reset All Conditions');
+        fireEvent.click(button3);
+        await waitFor(() =>  expect(screen.getAllByTestId('CheckBoxIcon').length).toBe(2));
+    });
 
 })


### PR DESCRIPTION
- Changed so unmet conditions switch show the conditions which are checked instead of unchecked
- Saves data about changing the conditions in an array (there is some redundancy, but this is the best way to do it I think, we can talk about it if not)
- Implements reset conditions button
- shows when a condition is edited
- unit testing
<img width="1470" alt="Screenshot 2023-10-16 at 12 17 00 AM" src="https://github.com/mnsavage/pdf_parser_front_end/assets/80489765/1e6cc476-8096-4214-bb80-acb2ace7344f">

