### PR TITLE
feat: GET protocol data from api upload endpoint

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,12 +8,19 @@ import Inspect from './views/Inspect/Inspect';
 import theme from './utils/theme';
 import pageOption from './utils/pageOption';
 import pdfRequirementsMet from './views/Inspect/_test_/mocks';
+import {fetchUploadGetData} from './services/api'
+import jsonData from './config.json';
 
 const App = () => {
   const [page, setPage] = useState(pageOption.Upload);
   const [uploadedFiles, setUploadedFiles] = useState(null);
   // being mocked rn, but this should send a post and retrieve if the requirements are met data for each PDF
   const [requirementsList, setRequirementsList] = useState(pdfRequirementsMet.files);
+  // fetch get data from upload API
+  const apiDomain = jsonData.apiURL
+  console.log(`API domain: ${apiDomain}`)
+  const getUploadData = fetchUploadGetData(apiDomain);
+  console.log(getUploadData);
 
   const update = (next) => {
     setPage(next);

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,3 @@
+{
+    "apiURL":"API_URL_NOT_HERE"
+}

--- a/src/services/_test_/api.test.js
+++ b/src/services/_test_/api.test.js
@@ -1,0 +1,46 @@
+import React, { render } from '@testing-library/react';
+import { fetchUploadGetData } from '../api';
+import { act } from 'react-dom/test-utils';
+import PropTypes from 'prop-types';
+
+// mocking fetch
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ data: 'some data' }),
+  })
+);
+
+// Mock component to use our hook
+function MockComponent(props) {
+  fetchUploadGetData(props.url);
+  return null; // Render nothing
+}
+
+MockComponent.propTypes = {
+  url: PropTypes.string.isRequired
+};
+
+export default MockComponent;
+
+describe('fetchUploadGetData hook', () => {
+  it('fetches data on mount', async () => {
+    const mockURL = 'http://test-url.com/';
+
+    // Reset fetch mock and setup the desired mock behavior
+    fetch.mockClear();
+    fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: 'some data' }),
+      })
+    );
+
+    await act(async () => {
+      render(<MockComponent url={mockURL} />);
+    });
+
+    expect(fetch).toHaveBeenCalledWith(`${mockURL}upload`);
+  });
+});
+

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,19 @@
+import React, { useEffect } from 'react';
+
+export const fetchUploadGetData = async (url) => {
+  useEffect(() => {
+    // Extract the API URL from the imported JSON file
+    const API_URL = `${url}upload`;
+    console.log(`upload API url: ${API_URL}`);
+
+    // Use the Fetch API to make the GET request
+    fetch(API_URL)
+      .then((response) => {
+        if(!response.ok){ // check status code
+          throw new Error(`HTTP error, status = ${response.status}`);
+        }
+        return response.json();
+      })
+      .catch((error) => console.log('Error fetching get data from API:', error));
+  }, []);
+}


### PR DESCRIPTION
## Description:
- I made the front-end to retrieve GET protocol data from the API upload endpoint. This is testing that the front-end is connect to the back-end  

## Image of front-end console logging the data from GET:
![successfull_GET_API_call](https://github.com/mnsavage/pdf_parser_front_end/assets/60998598/11437238-2771-4f7d-869a-747bca61d5f2)
